### PR TITLE
feat(customer): allow getting customer by customerId

### DIFF
--- a/openapi/paths/customer/get/index.yaml
+++ b/openapi/paths/customer/get/index.yaml
@@ -2,7 +2,7 @@ get:
   parameters:
     - name: identifier
       in: path
-      description: must be username
+      description: can be either username or customerId
       required: true
       schema:
         type: string

--- a/src/functions/customer.function.ts
+++ b/src/functions/customer.function.ts
@@ -35,7 +35,7 @@ app.http("customerIsBusiness", {
 app.http("customerGet", {
   methods: ["GET"],
   authLevel: "anonymous",
-  route: "customer/{username?}",
+  route: "customer/{identifier?}",
   handler: CustomerControllerGet,
 });
 

--- a/src/functions/customer/controllers/customer/get.spec.ts
+++ b/src/functions/customer/controllers/customer/get.spec.ts
@@ -20,12 +20,28 @@ describe("CustomerControllerGet", () => {
   it("Should be able to get user by username", async () => {
     const user = await createUser({ customerId: 123 }, { username: "test" });
     request = await createHttpRequest<CustomerControllerGetRequest>({
-      query: { username: user.username },
+      query: { identifier: user.username },
     });
 
     const res: HttpSuccessResponse<CustomerControllerGetResponse> =
       await CustomerControllerGet(request, context);
 
+    console.log(res.jsonBody);
+    expect(res.jsonBody?.success).toBeTruthy();
+    expect(res.jsonBody).toHaveProperty("payload");
+    expect(res.jsonBody?.payload?.fullname).toEqual(user.fullname);
+  });
+
+  it("Should be able to get user by customerId", async () => {
+    const user = await createUser({ customerId: 123 }, { username: "test" });
+    request = await createHttpRequest<CustomerControllerGetRequest>({
+      query: { identifier: 123 },
+    });
+
+    const res: HttpSuccessResponse<CustomerControllerGetResponse> =
+      await CustomerControllerGet(request, context);
+
+    console.log(res.jsonBody);
     expect(res.jsonBody?.success).toBeTruthy();
     expect(res.jsonBody).toHaveProperty("payload");
     expect(res.jsonBody?.payload?.fullname).toEqual(user.fullname);

--- a/src/functions/customer/controllers/customer/get.ts
+++ b/src/functions/customer/controllers/customer/get.ts
@@ -1,5 +1,4 @@
 import { z } from "zod";
-import { UserZodSchema } from "~/functions/user";
 import { _ } from "~/library/handler";
 import { CustomerServiceGet } from "../../services";
 
@@ -7,8 +6,8 @@ export type CustomerControllerGetRequest = {
   query: z.infer<typeof CustomerServiceGetSchema>;
 };
 
-export const CustomerServiceGetSchema = UserZodSchema.pick({
-  username: true,
+export const CustomerServiceGetSchema = z.object({
+  identifier: z.any(),
 });
 
 export type CustomerControllerGetResponse = Awaited<
@@ -18,6 +17,9 @@ export type CustomerControllerGetResponse = Awaited<
 export const CustomerControllerGet = _(
   async ({ query }: CustomerControllerGetRequest) => {
     const validateData = CustomerServiceGetSchema.parse(query);
-    return CustomerServiceGet(validateData);
+    return CustomerServiceGet({
+      username: validateData.identifier,
+      customerId: parseInt(validateData.identifier),
+    });
   }
 );

--- a/src/functions/customer/services/customer.spec.ts
+++ b/src/functions/customer/services/customer.spec.ts
@@ -1,5 +1,6 @@
 import { faker } from "@faker-js/faker";
 import {
+  CustomerServiceGet,
   CustomerServiceIsBusiness,
   CustomerServiceUpsert,
   CustomerServiceUpsertBody,
@@ -17,6 +18,7 @@ describe("CustomerService", () => {
       youtube: faker.internet.url(),
       twitter: faker.internet.url(),
     },
+    active: true,
     aboutMe: faker.lorem.paragraph(),
     avatar: faker.internet.avatar(),
     speaks: [faker.random.locale()],
@@ -29,6 +31,32 @@ describe("CustomerService", () => {
     );
 
     expect(newUser).toMatchObject(userData);
+  });
+
+  it("Should get the customer by customerId", async () => {
+    const newUser = await CustomerServiceUpsert(
+      { customerId: faker.datatype.number() },
+      userData
+    );
+
+    const user = await CustomerServiceGet({
+      customerId: newUser.customerId,
+    });
+
+    expect(user.customerId).toBe(newUser.customerId);
+  });
+
+  it("Should get the customer by username", async () => {
+    const newUser = await CustomerServiceUpsert(
+      { customerId: faker.datatype.number() },
+      userData
+    );
+
+    const user = await CustomerServiceGet({
+      username: newUser?.username,
+    });
+
+    expect(user.customerId).toBe(newUser.customerId);
   });
 
   it("Should check if customer exist", async () => {

--- a/src/functions/customer/services/customer.ts
+++ b/src/functions/customer/services/customer.ts
@@ -39,10 +39,17 @@ export const CustomerServiceIsBusiness = async (
   return { exists: user ? true : false };
 };
 
-export type CustomerServiceGetPRops = Pick<User, "username">;
+export type CustomerServiceGetProps = Partial<
+  Pick<User, "username" | "customerId">
+>;
 
-export const CustomerServiceGet = async (filter: CustomerServiceGetPRops) => {
-  return await UserModel.findOne({ ...filter, active: true })
+export const CustomerServiceGet = async (filter: CustomerServiceGetProps) => {
+  const orConditions = [
+    { username: filter?.username || "" },
+    { customerId: filter?.customerId || 0 },
+  ];
+
+  return UserModel.findOne({ $or: orConditions, active: true })
     .lean()
     .orFail(
       new NotFoundError([


### PR DESCRIPTION
This commit adds support for getting a customer by customerId in addition to the existing support for getting a customer by username. The `CustomerServiceGet` function now accepts an object with either a `username` or `customerId` property to filter the customer to be returned.

The `CustomerControllerGet` function has been updated to use the new `identifier` query parameter instead of the old `username` parameter. The `CustomerServiceGetSchema` has also been updated to reflect this change.

The OpenAPI specification for the `GET /customer` endpoint has been updated to reflect that the `identifier` parameter can now be either a `username` or a `customerId`.