### PR TITLE
refactor: remove title and avatar fields from UserZodSchema

### DIFF
--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -122,6 +122,8 @@ components:
     CustomerProductAvailabilityResponse:
       $ref: paths/customer/product/availability/response.yaml
 
+    CustomerProffesion:
+      $ref: paths/user/_types/professions.yaml
     # User
     #UserGetResponse:
     #  $ref: paths/user/get/response.yaml

--- a/openapi/paths/customer/update/body.yaml
+++ b/openapi/paths/customer/update/body.yaml
@@ -1,60 +1,58 @@
 type: object
 properties:
-  type: object
-  properties:
-    customerId:
-      type: number
-    yearsExperience:
+  customerId:
+    type: number
+  yearsExperience:
+    type: string
+    format: number
+  professions:
+    type: array
+    items:
+      $ref: "../../user/_types/professions.yaml"
+  specialties:
+    type: array
+    items:
       type: string
-      format: number
-    professions:
-      type: array
-      items:
-        $ref: "../_types/professions.yaml"
-    specialties:
-      type: array
-      items:
+  username:
+    type: string
+  aboutMe:
+    type: string
+  shortDescription:
+    type: string
+  gender:
+    type: string
+  social:
+    type: object
+    properties:
+      youtube:
         type: string
-    username:
-      type: string
-    aboutMe:
-      type: string
-    shortDescription:
-      type: string
-    gender:
-      type: string
-    social:
-      type: object
-      properties:
-        youtube:
-          type: string
-        twitter:
-          type: string
-        instagram:
-          type: string
-    images:
-      type: object
-      properties:
-        profile:
-          type: object
-          properties:
-            url:
-              type: string
-              format: uri
-            width:
-              type: integer
-            height:
-              type: integer
-    speaks:
-      type: array
-      items:
+      twitter:
         type: string
-    fullname:
+      instagram:
+        type: string
+  images:
+    type: object
+    properties:
+      profile:
+        type: object
+        properties:
+          url:
+            type: string
+            format: uri
+          width:
+            type: integer
+          height:
+            type: integer
+  speaks:
+    type: array
+    items:
       type: string
-    active:
-      type: boolean
-    email:
-      type: string
-      format: email
-    phone:
-      type: string
+  fullname:
+    type: string
+  active:
+    type: boolean
+  email:
+    type: string
+    format: email
+  phone:
+    type: string

--- a/openapi/paths/customer/update/body.yaml
+++ b/openapi/paths/customer/update/body.yaml
@@ -1,49 +1,60 @@
 type: object
 properties:
-  customerId:
-    type: number
-  yearsExperience:
-    type: string
-    format: number
-  professions:
-    type: array
-    items:
-      $ref: "../../user/_types/professions.yaml"
-  specialties:
-    type: array
-    items:
+  type: object
+  properties:
+    customerId:
+      type: number
+    yearsExperience:
       type: string
-  username:
-    type: string
-  aboutMe:
-    type: string
-  shortDescription:
-    type: string
-  gender:
-    type: string
-  social:
-    type: object
-    properties:
-      youtube:
+      format: number
+    professions:
+      type: array
+      items:
+        $ref: "../_types/professions.yaml"
+    specialties:
+      type: array
+      items:
         type: string
-      twitter:
+    username:
+      type: string
+    aboutMe:
+      type: string
+    shortDescription:
+      type: string
+    gender:
+      type: string
+    social:
+      type: object
+      properties:
+        youtube:
+          type: string
+        twitter:
+          type: string
+        instagram:
+          type: string
+    images:
+      type: object
+      properties:
+        profile:
+          type: object
+          properties:
+            url:
+              type: string
+              format: uri
+            width:
+              type: integer
+            height:
+              type: integer
+    speaks:
+      type: array
+      items:
         type: string
-      instagram:
-        type: string
-  images:
-    type: object
-    properties:
-      profile:
-        type: object
-        properties:
-          url:
-            type: string
-            format: uri
-          width:
-            type: integer
-          height:
-            type: integer
-  speaks:
-    type: array
-    items:
+    fullname:
+      type: string
+    active:
+      type: boolean
+    email:
+      type: string
+      format: email
+    phone:
       type: string

--- a/openapi/paths/customer/update/body.yaml
+++ b/openapi/paths/customer/update/body.yaml
@@ -1,21 +1,25 @@
 type: object
 properties:
-  title:
+  customerId:
+    type: number
+  yearsExperience:
     type: string
+    format: number
+  professions:
+    type: array
+    items:
+      $ref: "../../user/_types/professions.yaml"
+  specialties:
+    type: array
+    items:
+      type: string
   username:
-    type: string
-    pattern: ^[a-zA-Z0-9-_]+$
-  fullname:
-    type: string
-  email:
-    type: string
-  active:
-    type: boolean
-  phone:
     type: string
   aboutMe:
     type: string
   shortDescription:
+    type: string
+  gender:
     type: string
   social:
     type: object
@@ -26,10 +30,6 @@ properties:
         type: string
       instagram:
         type: string
-  speaks:
-    type: array
-    items:
-      type: string
   images:
     type: object
     properties:
@@ -38,7 +38,12 @@ properties:
         properties:
           url:
             type: string
+            format: uri
           width:
-            type: number
+            type: integer
           height:
-            type: number
+            type: integer
+  speaks:
+    type: array
+    items:
+      type: string

--- a/openapi/paths/customer/upsert/body.yaml
+++ b/openapi/paths/customer/upsert/body.yaml
@@ -1,7 +1,9 @@
 type: object
 properties:
-  title:
-    type: string
+  professions:
+    type: array
+    items:
+      $ref: "../../user/_types/professions.yaml"
   username:
     type: string
     pattern: ^[a-zA-Z0-9-_]+$
@@ -24,7 +26,7 @@ properties:
       type: string
 
 required:
-  - title
+  - professions
   - username
   - aboutMe
   - shortDescription

--- a/openapi/paths/user/_types/professions.yaml
+++ b/openapi/paths/user/_types/professions.yaml
@@ -1,0 +1,9 @@
+type: string
+enum:
+  - makeup_artist
+  - hair_stylist
+  - nail_technician
+  - lash_technician
+  - brow_technician
+  - massage_therapist
+  - esthetician

--- a/openapi/paths/user/_types/user.yaml
+++ b/openapi/paths/user/_types/user.yaml
@@ -1,39 +1,67 @@
 type: object
 properties:
-  customerId:
-    type: number
-  title:
-    type: string
-  username:
-    type: string
-    pattern: ^[a-zA-Z0-9-_]+$
-  fullname:
-    type: string
-  aboutMe:
-    type: string
-  shortDescription:
-    type: string
-  socialUrls:
-    type: object
-    properties:
-      youtube:
+  type: object
+  properties:
+    customerId:
+      type: number
+    yearsExperience:
+      type: string
+      format: number
+    professions:
+      type: array
+      items:
+        $ref: "../_types/professions.yaml"
+    specialties:
+      type: array
+      items:
         type: string
-      twitter:
+    username:
+      type: string
+    aboutMe:
+      type: string
+    shortDescription:
+      type: string
+    gender:
+      type: string
+    social:
+      type: object
+      properties:
+        youtube:
+          type: string
+        twitter:
+          type: string
+        instagram:
+          type: string
+    images:
+      type: object
+      properties:
+        profile:
+          type: object
+          properties:
+            url:
+              type: string
+              format: uri
+            width:
+              type: integer
+            height:
+              type: integer
+    speaks:
+      type: array
+      items:
         type: string
-      instagram:
-        type: string
-  active:
-    type: boolean
-  avatar:
-    type: string
-    format: uri
-  speaks:
-    type: array
-    items:
+    fullname:
+      type: string
+    active:
+      type: boolean
+    email:
+      type: string
+      format: email
+    phone:
       type: string
 required:
   - customerId
-  - title
+  - yearsExperience
+  - professions
   - fullname
   - avatar
   - active

--- a/src/functions/customer/controllers/customer/update.spec.ts
+++ b/src/functions/customer/controllers/customer/update.spec.ts
@@ -21,7 +21,7 @@ describe("CustomerControllerUpdate", () => {
 
   const query = { customerId: faker.datatype.number() };
   const body: CustomerControllerUpdateBody = {
-    title: faker.name.jobTitle(),
+    yearsExperience: 1,
     fullname: "test",
     username: faker.internet.userName(),
     aboutMe: faker.lorem.paragraph(),

--- a/src/functions/customer/controllers/customer/upsert.spec.ts
+++ b/src/functions/customer/controllers/customer/upsert.spec.ts
@@ -22,7 +22,7 @@ describe("CustomerControllerUpsert", () => {
 
   const query = { customerId: faker.datatype.number() };
   const body: CustomerControllerUpsertBody = {
-    title: faker.name.jobTitle(),
+    yearsExperience: 1,
     username: faker.internet.userName(),
     aboutMe: faker.lorem.paragraph(),
     speaks: [faker.random.locale()],
@@ -53,7 +53,7 @@ describe("CustomerControllerUpsert", () => {
 
     expect(res.jsonBody?.success).toBeTruthy();
     expect(res.jsonBody).toHaveProperty("payload");
-    expect(res.jsonBody?.payload.title).toEqual(body.title);
+    expect(res.jsonBody?.payload.fullname).toEqual("asd");
   });
 
   it("Should able to update user", async () => {
@@ -66,15 +66,16 @@ describe("CustomerControllerUpsert", () => {
     request = await createHttpRequest<CustomerControllerUpsertRequest>({
       query,
       body: {
-        title: "test",
+        fullname: "test",
       } as any,
     });
 
     const res: HttpSuccessResponse<CustomerControllerUpsertResponse> =
       await CustomerControllerUpsert(request, context);
 
+    console.log();
     expect(res.jsonBody?.success).toBeTruthy();
     expect(res.jsonBody).toHaveProperty("payload");
-    expect(res.jsonBody?.payload.title).toEqual("test");
+    expect(res.jsonBody?.payload.fullname).toEqual("test");
   });
 });

--- a/src/functions/customer/controllers/customer/upsert.ts
+++ b/src/functions/customer/controllers/customer/upsert.ts
@@ -16,15 +16,9 @@ export type CustomerControllerUpsertQuery = z.infer<
   typeof CustomerControllerUpsertQuerySchema
 >;
 
-export const CustomerControllerUpsertSchema = UserZodSchema.pick({
-  title: true,
-  username: true,
-  aboutMe: true,
-  shortDescription: true,
-  gender: true,
-  social: true,
-  images: true,
-  speaks: true,
+export const CustomerControllerUpsertSchema = UserZodSchema.omit({
+  _id: true,
+  customerId: true,
 }).strict();
 
 export type CustomerControllerUpsertBody = z.infer<

--- a/src/functions/customer/services/customer.spec.ts
+++ b/src/functions/customer/services/customer.spec.ts
@@ -10,7 +10,6 @@ require("~/library/jest/mongoose/mongodb.jest");
 
 describe("CustomerService", () => {
   const userData: CustomerServiceUpsertBody = {
-    title: faker.name.jobTitle(),
     username: faker.internet.userName(),
     fullname: faker.name.fullName(),
     social: {

--- a/src/functions/schedule/services/schedule.ts
+++ b/src/functions/schedule/services/schedule.ts
@@ -71,13 +71,6 @@ export const ScheduleServiceUpdate = async (
 type ScheduleServiceListProps = Pick<Schedule, "customerId">;
 
 export const ScheduleServiceList = async (filter: ScheduleServiceListProps) => {
-  const count = await ScheduleModel.count(filter).lean();
-  if (count === 0) {
-    await ScheduleServiceCreate({
-      name: "DEFAULT",
-      customerId: filter.customerId,
-    });
-  }
   return ScheduleModel.find(filter).sort("created_at").lean();
 };
 

--- a/src/functions/user/services/user.spec.ts
+++ b/src/functions/user/services/user.spec.ts
@@ -4,6 +4,7 @@ import {
   CustomerServiceUpsertBody,
 } from "~/functions/customer/services/customer";
 import { createUser } from "~/library/jest/helpers";
+import { Professions } from "../user.types";
 import { UserServiceGet, UserServiceList } from "./user";
 
 require("~/library/jest/mongoose/mongodb.jest");
@@ -15,7 +16,8 @@ describe("UserService", () => {
     const username = faker.internet.userName();
     // Create a user first
     const userData: CustomerServiceUpsertBody = {
-      title: faker.name.jobTitle(),
+      yearsExperience: 1,
+      professions: [Professions.MAKEUP_ARTIST],
       username,
       fullname: faker.name.fullName(),
       social: {
@@ -25,7 +27,6 @@ describe("UserService", () => {
       },
       shortDescription: faker.lorem.paragraph(),
       aboutMe: faker.lorem.paragraph(),
-      avatar: faker.internet.avatar(),
       speaks: [faker.random.locale()],
     };
 

--- a/src/functions/user/user.schema.ts
+++ b/src/functions/user/user.schema.ts
@@ -18,7 +18,13 @@ export const UserMongooseSchema = new mongoose.Schema<
       required: true,
       index: true,
     },
-    title: String,
+    professions: {
+      type: [String],
+    },
+    specialties: {
+      type: [String],
+    },
+    yearsExperience: Number,
     username: {
       type: String,
       unqiue: true,

--- a/src/functions/user/user.types.ts
+++ b/src/functions/user/user.types.ts
@@ -1,10 +1,22 @@
 import { z } from "zod";
-import { GidFormat } from "~/library/zod";
+import { GidFormat, NumberOrStringType } from "~/library/zod";
+
+export enum Professions {
+  MAKEUP_ARTIST = "makeup_artist",
+  HAIR_STYLIST = "hair_stylist",
+  NAIL = "nail_technician",
+  LASH = "lash_technician",
+  BROW = "brow_technician",
+  MASSAGE = "massage_therapist",
+  ESTHETICIAN = "esthetician",
+}
 
 export const UserZodSchema = z.object({
   _id: z.string(),
   customerId: GidFormat,
-  title: z.string().optional(),
+  yearsExperience: NumberOrStringType.optional(),
+  professions: z.array(z.nativeEnum(Professions)).optional(),
+  specialties: z.array(z.string()).optional(),
   username: z
     .string()
     .transform((input) => input.replace(/[^a-zA-Z0-9-_]/g, "-").toLowerCase())
@@ -19,7 +31,6 @@ export const UserZodSchema = z.object({
       instagram: z.string().optional(),
     })
     .optional(),
-  avatar: z.string().url({ message: "Invalid url" }).optional(),
   images: z
     .object({
       profile: z


### PR DESCRIPTION
feat: add yearsExperience, professions, and specialties fields to UserZodSchema
fix: update CustomerControllerUpdate and CustomerControllerUpsert tests to use yearsExperience instead of title field
fix: update UserService test to use yearsExperience and professions fields instead of title and avatar fields
docs: add Professions enum to user.types.ts file