### PR TITLE
fix(openapi): change parameter name from 'productId' to 'productHandl…

### DIFF
--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -251,7 +251,7 @@ paths:
     $ref: "./paths/user/products/list-by-location/index.yaml"
   /user/{username}/products/location/{locationId}:
     $ref: "./paths/user/products/get-products/index.yaml"
-  /user/{username}/schedule/get-by-product-id/{productId}:
+  /user/{username}/schedule/get-by-product-id/{productHandle}:
     $ref: paths/user/schedule/get-by-product/index.yaml
   /user/{username}/schedules/locations:
     $ref: "./paths/user/schedule/list/index.yaml"

--- a/openapi/paths/user/schedule/get-by-product/index.yaml
+++ b/openapi/paths/user/schedule/get-by-product/index.yaml
@@ -6,9 +6,9 @@ get:
       required: true
       schema:
         type: string
-    - name: productId
+    - name: productHandle
       in: path
-      description: product Id
+      description: productHandle
       required: true
       schema:
         type: string
@@ -16,7 +16,7 @@ get:
     - UserSchedule
   operationId: userScheduleGetByProduct
   summary: GET Get user schedule
-  description: This endpoint should retrieve a schedule and locations belonging to a specific productId, along with the product.
+  description: This endpoint should retrieve a schedule and locations belonging to a specific productHandle, along with the product.
   responses:
     "200":
       description: Response with payload

--- a/src/functions/user/controllers/schedule/get-by-product.ts
+++ b/src/functions/user/controllers/schedule/get-by-product.ts
@@ -1,7 +1,6 @@
 import { z } from "zod";
 
 import { _ } from "~/library/handler";
-import { NumberOrStringType } from "~/library/zod";
 import { UserScheduleServiceGetByProductId as UserScheduleServiceGetByProduct } from "../../services/schedule/get-by-product";
 import { UserServiceGetCustomerId } from "../../services/user";
 
@@ -11,7 +10,7 @@ export type UserScheduleControllerGetByProductRequest = {
 
 const UserScheduleControllerGetByProductQuerySchema = z.object({
   username: z.string(),
-  productId: NumberOrStringType,
+  productHandle: z.string(),
 });
 
 export type UserScheduleControllerGetByProductResponse = Awaited<
@@ -24,7 +23,7 @@ export const UserScheduleControllerGetByProduct = _(
       UserScheduleControllerGetByProductQuerySchema.parse(query);
     const user = await UserServiceGetCustomerId(validateQuery);
     return UserScheduleServiceGetByProduct({
-      productId: validateQuery.productId,
+      productHandle: validateQuery.productHandle,
       customerId: user.customerId,
     });
   }

--- a/src/functions/user/services/schedule/get-by-product.spec.ts
+++ b/src/functions/user/services/schedule/get-by-product.spec.ts
@@ -76,7 +76,7 @@ describe("UserScheduleServiceGetByProductId", () => {
 
     const getSchedule = await UserScheduleServiceGetByProductId({
       customerId: schedule.customerId,
-      productId: product.productId,
+      productHandle: product.productHandle,
     });
 
     expect(getSchedule!.name).toBe(schedule.name);

--- a/src/functions/user/services/schedule/get-by-product.ts
+++ b/src/functions/user/services/schedule/get-by-product.ts
@@ -9,21 +9,21 @@ export type UesrScheduleAggreateReturnValue = Pick<
 
 export type UserScheduleServiceGetByProductIdProps = {
   customerId: number;
-  productId: number;
+  productHandle: string;
 };
 
 export async function UserScheduleServiceGetByProductId({
   customerId,
-  productId,
+  productHandle,
 }: UserScheduleServiceGetByProductIdProps) {
   // first just the schedule with the product
   const schedule = await ScheduleModel.findOne({
     customerId,
-    "products.productId": productId,
+    "products.productHandle": productHandle,
   }).orFail(
     new NotFoundError([
       {
-        path: ["customerId", "productId"],
+        path: ["customerId", "productHandle"],
         message: "NOT_FOUND",
         code: "custom",
       },
@@ -43,7 +43,7 @@ export async function UserScheduleServiceGetByProductId({
       },
       {
         $match: {
-          "products.productId": productId,
+          "products.productHandle": productHandle,
         },
       },
       {

--- a/src/library/availability/generate-availability.spec.ts
+++ b/src/library/availability/generate-availability.spec.ts
@@ -83,6 +83,7 @@ describe("generateAvailability", () => {
       (slot) =>
         isEqual(slot.from, randomSlot.from) && isEqual(slot.to, randomSlot.to)
     );
+
     expect(slot).toBeDefined();
   });
 


### PR DESCRIPTION
…e' in /user/{username}/schedule/get-by-product-id/{productHandle} endpoint

fix(openapi): update description of /user/{username}/schedule/get-by-product-id/{productHandle} endpoint to reflect the change in parameter name fix(user/controllers/schedule/get-by-product.ts): update parameter name from 'productId' to 'productHandle' in UserScheduleControllerGetByProductQuerySchema fix(user/controllers/schedule/get-by-product.ts): update parameter name from 'productId' to 'productHandle' in UserScheduleControllerGetByProduct function fix(user/services/schedule/get-by-product.ts): update parameter name from 'productId' to 'productHandle' in UserScheduleServiceGetByProductIdProps fix(user/services/schedule/get-by-product.ts): update property name from 'productId' to 'productHandle' in UserScheduleServiceGetByProductId function fix(user/services/schedule/get-by-product