### PR TITLE
Remove price from availability slots and add parentId to link products

### DIFF
--- a/openapi/paths/user/availability/_types/slot.yaml
+++ b/openapi/paths/user/availability/_types/slot.yaml
@@ -9,16 +9,8 @@ properties:
     items:
       type: object
       properties:
-        price:
-          type: object
-          properties:
-            amount:
-              type: string
-            currencyCode:
-              type: string
-          required:
-            - amount
-            - currencyCode
+        parentId:
+          type: number
         productId:
           type: number
         variantId:
@@ -32,7 +24,6 @@ properties:
         duration:
           type: number
       required:
-        - price
         - productId
         - variantId
         - from

--- a/src/functions/availability/availability.types.ts
+++ b/src/functions/availability/availability.types.ts
@@ -5,10 +5,11 @@ import { User } from "../user/user.types";
 export type AvailabilityProducts = Array<
   Pick<
     ScheduleProduct,
-    "productId" | "variantId" | "price" | "breakTime" | "duration"
+    "productId" | "variantId" | "breakTime" | "duration"
   > & {
     from: Date;
     to: Date;
+    parentId?: number;
   }
 >;
 

--- a/src/functions/user/services/availability/generate.ts
+++ b/src/functions/user/services/availability/generate.ts
@@ -45,22 +45,20 @@ export const UserAvailabilityServiceGenerate = async (
   const optionIds = body.optionIds ? body.optionIds : null;
   if (optionIds) {
     schedule.products = schedule.products.reduce((products, currentProduct) => {
-      currentProduct.options?.forEach((option) => {
-        if (optionIds.hasOwnProperty(option.productId.toString())) {
-          const requiredVariantId = optionIds[option.productId];
-          const variant = option.variants.find(
+      currentProduct.options?.forEach((currentProductOption) => {
+        if (
+          optionIds.hasOwnProperty(currentProductOption.productId.toString())
+        ) {
+          const requiredVariantId = optionIds[currentProductOption.productId];
+          const variant = currentProductOption.variants.find(
             (v) => v.variantId === requiredVariantId
           );
           if (variant) {
             products.push({
               variantId: variant.variantId,
               duration: variant.duration,
+              productId: currentProductOption.productId,
               breakTime: 0,
-              price: {
-                amount: "0.0",
-                currencyCode: "DKK",
-              },
-              productId: option.productId,
               bookingPeriod: {
                 unit: TimeUnit.MONTHS,
                 value: 12,
@@ -69,6 +67,7 @@ export const UserAvailabilityServiceGenerate = async (
                 unit: TimeUnit.HOURS,
                 value: 1,
               },
+              parentId: currentProduct.productId,
             });
           }
         }

--- a/src/functions/user/services/schedule/get-with-customer.ts
+++ b/src/functions/user/services/schedule/get-with-customer.ts
@@ -20,10 +20,9 @@ export type UserScheduleServiceGetWithCustomerResponse = Omit<
       | "variantId"
       | "options"
       | "breakTime"
-      | "price"
       | "noticePeriod"
       | "bookingPeriod"
-    >
+    > & { parentId?: number }
   >;
 };
 

--- a/src/library/availability/generate-availability.ts
+++ b/src/library/availability/generate-availability.ts
@@ -104,9 +104,9 @@ export const generateAvailability = async ({
             });
 
             slotProducts.push({
+              parentId: product.parentId,
               productId: product.productId,
               variantId: product.variantId,
-              price: product.price,
               from: productStartTime,
               to: productEndTime,
               breakTime: product.breakTime,


### PR DESCRIPTION
## **Type**
enhancement


___

## **Description**
- Removed the `price` attribute from various product and slot definitions across multiple files.
- Introduced a new `parentId` attribute to link products and enhance relational data handling.
- Refactored and improved code clarity in product generation logic.
- Updated OpenAPI documentation to reflect changes in data structure.


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>availability.types.ts</strong><dd><code>Update AvailabilityProducts Type Definition</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/functions/availability/availability.types.ts
<li>Removed <code>price</code> from <code>AvailabilityProducts</code> type.<br> <li> Added optional <code>parentId</code> to <code>AvailabilityProducts</code> type.


</details>
    

  </td>
  <td><a href="https://github.com/jamalsoueidan/booking-api/pull/137/files#diff-2cd51445bc1dfe0f3a028bfdc90318624a00f212b35cd85a3a928282044f68fd">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>generate.ts</strong><dd><code>Refactor and Update Product Generation Logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/functions/user/services/availability/generate.ts
<li>Refactored variable names for clarity.<br> <li> Removed <code>price</code> from the product push operation.<br> <li> Added <code>parentId</code> linking to the <code>currentProduct</code>.


</details>
    

  </td>
  <td><a href="https://github.com/jamalsoueidan/booking-api/pull/137/files#diff-ca0ab342464af72ff18cb7538e9a1a16a0b14b2860a54ba1f732f43d416ef86f">+8/-9</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>get-with-customer.ts</strong><dd><code>Modify Schedule Service Response Structure</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/functions/user/services/schedule/get-with-customer.ts
<li>Removed <code>price</code> from the response type.<br> <li> Added optional <code>parentId</code> to the response type.


</details>
    

  </td>
  <td><a href="https://github.com/jamalsoueidan/booking-api/pull/137/files#diff-65edbb54979777800e23027ca170bc15fc5145f03ae79635876d3433967515cb">+1/-2</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>generate-availability.ts</strong><dd><code>Adjust Slot Product Attributes in Availability Generation</code></dd></summary>
<hr>

src/library/availability/generate-availability.ts
<li>Added <code>parentId</code> to the slot products.<br> <li> Removed <code>price</code> from the slot products.


</details>
    

  </td>
  <td><a href="https://github.com/jamalsoueidan/booking-api/pull/137/files#diff-0b64eec44c23daf66b8160e3918a3b0ad9e7d1e52b176427223c8fda2e850f0a">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>slot.yaml</strong><dd><code>Update OpenAPI Slot Type Definition</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

openapi/paths/user/availability/_types/slot.yaml
<li>Removed <code>price</code> object from slot properties.<br> <li> Added <code>parentId</code> as a new property.


</details>
    

  </td>
  <td><a href="https://github.com/jamalsoueidan/booking-api/pull/137/files#diff-c8812ab5ffa4b09d651d11253b6d6962fcde2f1308cd30c79e9c4d0a697af838">+2/-11</a>&nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

